### PR TITLE
Adds tracking events for carrier collection and return

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /composer.lock
+.history/

--- a/Utils/MessageTypeRD.php
+++ b/Utils/MessageTypeRD.php
@@ -44,4 +44,5 @@ trait MessageTypeRD
     public const MT_SEARCHING_FOR_DELIVERER = 'Other';
     public const MT_QUOTATION = 'Other';
     public const MT_DELIVERYMAN_ABANDONED_THE_ORDER = 'Other';
+    public const MT_COLLECTED_BY_THE_CARRIER = 'Other';
 }

--- a/Utils/StopSeqRD.php
+++ b/Utils/StopSeqRD.php
@@ -44,4 +44,5 @@ trait StopSeqRD
     public const STQ_SEARCHING_FOR_DELIVERER = '1';
     public const STQ_QUOTATION = '1';
     public const STQ_DELIVERYMAN_ABANDONED_THE_ORDER = '1';
+    public const STQ_COLLECTED_BY_THE_CARRIER = '1';
 }

--- a/src/Trackings.php
+++ b/src/Trackings.php
@@ -153,6 +153,20 @@ class Trackings
         return ['tracinkg' => $this->tracking($data), 'data' => $data];
     }
 
+    public function collectedByTheCarrier()
+    {
+        $messageData = [
+            'MessageComments' => now('UTC')->toDateTimeLocalString(),
+            'MessageName' => 'Coletado pela transportadora',
+            'MessageType' => $this::MT_COLLECTED_BY_THE_CARRIER,
+            'StopSeq' => $this::STQ_COLLECTED_BY_THE_CARRIER,
+            'TrackingReasonCodeId' => $this::TRK_ORDER_PICKUP,
+        ];
+
+        $data = array_merge($this->baseTracking, $messageData);
+        return ['tracinkg' => $this->tracking($data), 'data' => $data];
+    }
+
     public function dispatched($expectedTime)
     {
         $messageData = [
@@ -312,6 +326,19 @@ class Trackings
             'MessageType' => $this::MT_ORDER_REFUSED_BY_CLIENT,
             'StopSeq' => $this::STQ_ORDER_REFUSED_BY_CLIENT,
             'TrackingReasonCodeId' => $this::TRK_ORDER_REFUSED_BY_CLIENT,
+        ];
+        $data = array_merge($this->baseTracking, $messageData);
+        return ['tracinkg' => $this->tracking($data), 'data' => $data];
+    }
+
+    public function onTheReturnRoute()
+    {
+        $messageData = [
+            'MessageComments' => now('UTC')->toDateTimeLocalString(),
+            'MessageName' => 'Em rota de devolução',
+            'MessageType' => $this::MT_IN_RETURN_PROCESS,
+            'StopSeq' => $this::STQ_IN_RETURN_PROCESS,
+            'TrackingReasonCodeId' => $this::TRK_IN_RETURN_PROCESS,
         ];
         $data = array_merge($this->baseTracking, $messageData);
         return ['tracinkg' => $this->tracking($data), 'data' => $data];


### PR DESCRIPTION
Improves order tracking visibility by adding new events for key delivery stages:
- Introduces constants and a dedicated method to generate a tracking message when an order is collected by the carrier.
- Adds a method to generate a tracking message for orders that are on their return route.
- Includes a `.gitignore` update to exclude the `.history/` directory.

Relates to BEE-11471